### PR TITLE
feat: add children to FileToolbar

### DIFF
--- a/packages/chonky/example/index.tsx
+++ b/packages/chonky/example/index.tsx
@@ -1,13 +1,29 @@
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
-import { FullFileBrowser } from '../dist/chonky.esm.js';
+import Typography from '@mui/material/Typography';
+import {
+  FileBrowser,
+  FileNavbar,
+  FileToolbar,
+  FileList,
+  FileContextMenu,
+} from '../dist/chonky.esm.js';
 import { ChonkyIconFA } from '../../chonky-icon-fontawesome';
 
 const App = () => {
   const pathEntries = ['test', 'folder'];
+  const [appendInfo, setAppendInfo] = React.useState('Test Info');
+  React.useEffect(() => {
+    var num = 0;
+    setInterval(() => {
+      setAppendInfo(`Test Info ${num}`);
+      num++;
+    }, 1000);
+  }, []);
+
   return (
     <div style={{ height: 400 }}>
-      <FullFileBrowser
+      <FileBrowser
         iconComponent={ChonkyIconFA}
         folderChain={pathEntries.map((name, idx) => ({
           id: `${idx}`,
@@ -17,7 +33,18 @@ const App = () => {
           { id: 'zxc', name: 'My File.txt' },
           { id: 'jre', name: 'My Folder' },
         ]}
-      />
+      >
+        <FileNavbar />
+        <FileToolbar>
+          <div className="chonky-infoContainer">
+            <Typography variant="body1" className="chonky-infoText">
+              {appendInfo}
+            </Typography>
+          </div>
+        </FileToolbar>
+        <FileList />
+        <FileContextMenu />
+      </FileBrowser>
     </div>
   );
 };

--- a/packages/chonky/src/components/external/FileToolbar.tsx
+++ b/packages/chonky/src/components/external/FileToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo } from 'react';
+import React, { ReactElement, ReactNode, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { selectToolbarItems, selectHideToolbarInfo } from '../../redux/selectors';
@@ -10,40 +10,43 @@ import { ToolbarSearch } from './ToolbarSearch';
 
 export interface FileToolbarProps {}
 
-export const FileToolbar: React.FC<FileToolbarProps> = React.memo(() => {
-  const classes = useStyles();
-  const toolbarItems = useSelector(selectToolbarItems);
+export const FileToolbar: React.FC<FileToolbarProps & { children?: ReactNode }> =
+  React.memo((props) => {
+    const { children } = props;
+    const classes = useStyles();
+    const toolbarItems = useSelector(selectToolbarItems);
 
-  const toolbarItemComponents = useMemo(() => {
-    const components: ReactElement[] = [];
-    for (let i = 0; i < toolbarItems.length; ++i) {
-      const item = toolbarItems[i];
+    const toolbarItemComponents = useMemo(() => {
+      const components: ReactElement[] = [];
+      for (let i = 0; i < toolbarItems.length; ++i) {
+        const item = toolbarItems[i];
 
-      const key = `toolbar-item-${typeof item === 'string' ? item : item.name}`;
-      const component =
-        typeof item === 'string' ? (
-          <SmartToolbarButton key={key} fileActionId={item} />
-        ) : (
-          <ToolbarDropdown key={key} {...item} />
-        );
-      components.push(component);
-    }
-    return components;
-  }, [toolbarItems]);
+        const key = `toolbar-item-${typeof item === 'string' ? item : item.name}`;
+        const component =
+          typeof item === 'string' ? (
+            <SmartToolbarButton key={key} fileActionId={item} />
+          ) : (
+            <ToolbarDropdown key={key} {...item} />
+          );
+        components.push(component);
+      }
+      return components;
+    }, [toolbarItems]);
 
-  const hideToolbarInfo = useSelector(selectHideToolbarInfo);
-  return (
-    <div className={classes.toolbarWrapper}>
-      <div className={classes.toolbarContainer}>
-        <div className={classes.toolbarLeft}>
-          <ToolbarSearch />
-          {!hideToolbarInfo && <ToolbarInfo />}
+    const hideToolbarInfo = useSelector(selectHideToolbarInfo);
+    return (
+      <div className={classes.toolbarWrapper}>
+        <div className={classes.toolbarContainer}>
+          <div className={classes.toolbarLeft}>
+            <ToolbarSearch />
+            {!hideToolbarInfo && <ToolbarInfo />}
+            {children}
+          </div>
+          <div className={classes.toolbarRight}>{toolbarItemComponents}</div>
         </div>
-        <div className={classes.toolbarRight}>{toolbarItemComponents}</div>
       </div>
-    </div>
-  );
-});
+    );
+  });
 
 const useStyles = makeGlobalChonkyStyles((theme) => ({
   toolbarWrapper: {},


### PR DESCRIPTION
Allow passthrough children to FileToolbar to display more information.